### PR TITLE
Create one worker for each camera

### DIFF
--- a/lib/event_notification.ex
+++ b/lib/event_notification.ex
@@ -32,7 +32,8 @@ defmodule EventNotification do
         new_entry: %FilerPb.Entry{name: new_file_name},
         old_entry: %FilerPb.Entry{name: old_file_name},
         new_parent_path: path
-      }), do: :noop
+      }),
+      do: :noop
 
   ##########
   # DELETE #

--- a/lib/seaweedfs_snapshots_db.ex
+++ b/lib/seaweedfs_snapshots_db.ex
@@ -8,11 +8,11 @@ defmodule SeaweedfsSnapshotsDb do
         module:
           {BroadwayKafka.Producer,
            [
-              hosts: [localhost: 9092],
-              group_id: "group_1",
-              topics: ["snapshotsDB"],
-              offset_commit_on_ack: false,
-              offset_commit_interval_seconds: 30
+             hosts: [localhost: 9092],
+             group_id: "group_1",
+             topics: ["snapshotsDB"],
+             offset_commit_on_ack: false,
+             offset_commit_interval_seconds: 30
            ]},
         concurrency: 10
       ],

--- a/lib/seaweedfs_snapshots_db.ex
+++ b/lib/seaweedfs_snapshots_db.ex
@@ -8,15 +8,17 @@ defmodule SeaweedfsSnapshotsDb do
         module:
           {BroadwayKafka.Producer,
            [
-             hosts: [localhost: 9092],
-             group_id: "group_1",
-             topics: ["snapshotsDB"]
+              hosts: [localhost: 9092],
+              group_id: "group_1",
+              topics: ["snapshotsDB"],
+              offset_commit_on_ack: false,
+              offset_commit_interval_seconds: 30
            ]},
-        concurrency: 1
+        concurrency: 10
       ],
       processors: [
         default: [
-          concurrency: 10
+          concurrency: 50
         ]
       ]
     )

--- a/lib/seaweedfs_snapshots_db/application.ex
+++ b/lib/seaweedfs_snapshots_db/application.ex
@@ -9,7 +9,8 @@ defmodule SeaweedfsSnapshotsDb.Application do
   def start(_type, _args) do
     children = [
       {SeaweedfsSnapshotsDb, []},
-      {Snapshots.Repo, []}
+      {Snapshots.Repo, []},
+      {SeaweedfsSupervisor, []}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/seaweedfs_snapshots_db/seaweedfs_supervisor.ex
+++ b/lib/seaweedfs_snapshots_db/seaweedfs_supervisor.ex
@@ -1,0 +1,38 @@
+defmodule SeaweedfsSupervisor do
+  use DynamicSupervisor
+  require Logger
+
+  def start_link(_args) do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_init_arg) do
+    Task.start_link(&initiate_workers/0)
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_worker(nil), do: :noop
+
+  def start_worker(camera) do
+    DynamicSupervisor.start_child(__MODULE__, {SeaweedfsWorker, camera})
+  end
+
+  def initiate_workers do
+    Logger.info("Initiate seaweedfs workers.")
+
+    {:ok, result} =
+      Snapshots.Repo.query(
+        "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'"
+      )
+
+    Enum.map(result.rows, fn camera ->
+      id = List.first(camera)
+
+      start_worker(%{
+        id: String.to_atom(id),
+        camera: id,
+        timestamps: []
+      })
+    end)
+  end
+end

--- a/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
+++ b/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
@@ -19,6 +19,7 @@ defmodule SeaweedfsWorker do
 
   def update_snapshots(pid, timestamp) do
     snapshots = GenServer.call(pid, {:update_snapshots, timestamp})
+
     if length(snapshots) >= 1 do
       GenServer.call(pid, :insert_snapshots)
     end
@@ -30,7 +31,7 @@ defmodule SeaweedfsWorker do
 
   def handle_call({:update_snapshots, timestamp}, _from, state) do
     new_state =
-        Map.replace(state, :timestamps, [%{snapshot_timestamp: timestamp} | state.timestamps])
+      Map.replace(state, :timestamps, [%{snapshot_timestamp: timestamp} | state.timestamps])
 
     {:reply, new_state.timestamps, new_state}
   end

--- a/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
+++ b/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
@@ -1,0 +1,51 @@
+defmodule SeaweedfsWorker do
+  use GenServer
+
+  require Logger
+
+  def start_link(opts) do
+    {id, opts} = Map.pop!(opts, :id)
+    GenServer.start_link(__MODULE__, opts, name: id)
+  end
+
+  def init(state) do
+    Process.flag(:trap_exit, true)
+    {:ok, state}
+  end
+
+  def get_state(pid) do
+    GenServer.call(pid, :get)
+  end
+
+  def update_snapshots(pid, timestamp) do
+    snapshots = GenServer.call(pid, {:update_snapshots, timestamp})
+    if length(snapshots) >= 1 do
+      GenServer.call(pid, :insert_snapshots)
+    end
+  end
+
+  def delete_snapshot(pid, timestamp) do
+    GenServer.cast(pid, {:delete_snapshot, timestamp})
+  end
+
+  def handle_call({:update_snapshots, timestamp}, _from, state) do
+    new_state =
+        Map.replace(state, :timestamps, [%{snapshot_timestamp: timestamp} | state.timestamps])
+
+    {:reply, new_state.timestamps, new_state}
+  end
+
+  def handle_call(:get, _from, state),
+    do: {:reply, state, state}
+
+  def handle_call(:insert_snapshots, _from, state) do
+    Snapshots.add_snapshots(state.timestamps, state.camera)
+    new_state = Map.replace(state, :timestamps, [])
+    {:reply, state, new_state}
+  end
+
+  def handle_cast({:delete_snapshot, timestamp}, state) do
+    Snapshots.delete_snapshot(timestamp, state.camera)
+    {:noreply, state}
+  end
+end

--- a/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
+++ b/lib/seaweedfs_snapshots_db/seaweedfs_worker.ex
@@ -20,7 +20,7 @@ defmodule SeaweedfsWorker do
   def update_snapshots(pid, timestamp) do
     snapshots = GenServer.call(pid, {:update_snapshots, timestamp})
 
-    if length(snapshots) >= 1 do
+    if length(snapshots) > 100 do
       GenServer.call(pid, :insert_snapshots)
     end
   end

--- a/lib/snapshots/snapshots.ex
+++ b/lib/snapshots/snapshots.ex
@@ -11,15 +11,12 @@ defmodule Snapshots do
     field(:number, :integer, virtual: true)
   end
 
-  def add_snapshot({:error, _reason}, _camera_exid), do: Logger.debug("NIL")
-
-  def add_snapshot({:ok, datetime, _offset}, camera_exid) do
-    %Snapshots{snapshot_timestamp: datetime}
-    |> Ecto.put_meta(source: camera_exid)
-    |> Snapshots.Repo.insert!(on_conflict: :nothing)
+  def add_snapshots(query \\ __MODULE__, timestamps, camera_exid) do
+    {camera_exid, query}
+    |> Snapshots.Repo.insert_all(timestamps, on_conflict: :nothing)
   end
 
-  def delete_snapshot(query \\ __MODULE__, {:ok, timestamp, _offset}, camera_exid) do
+  def delete_snapshot(query \\ __MODULE__, timestamp, camera_exid) do
     {camera_exid, query}
     |> where([s], s.snapshot_timestamp == ^timestamp)
     |> Snapshots.Repo.delete_all()

--- a/lib/snapshots/snapshots.ex
+++ b/lib/snapshots/snapshots.ex
@@ -1,5 +1,6 @@
 defmodule Snapshots do
   import Ecto.Changeset
+  import Ecto.Query
 
   require Logger
 
@@ -15,7 +16,13 @@ defmodule Snapshots do
   def add_snapshot({:ok, datetime, _offset}, camera_exid) do
     %Snapshots{snapshot_timestamp: datetime}
     |> Ecto.put_meta(source: camera_exid)
-    |> Snapshots.Repo.insert(on_conflict: :nothing)
+    |> Snapshots.Repo.insert!(on_conflict: :nothing)
+  end
+
+  def delete_snapshot(query \\ __MODULE__, {:ok, timestamp, _offset}, camera_exid) do
+    {camera_exid, query}
+    |> where([s], s.snapshot_timestamp == ^timestamp)
+    |> Snapshots.Repo.delete_all()
   end
 
   def changeset(model, params \\ :invalid) do


### PR DESCRIPTION
One supervised worker will be created for each table (camera) in the DB. This worker will accumulate the timestamps until it hits 100 timestamps and insert all of them at once.

The workers will also handle the deletions asynchronously.

The kafka producer concurrency has been increased to 10 so it will now generate 10 workers to handle the events.

`offset_commit_on_ack: false`: will increase performance since any commit requests will start respecting the `:offset_commit_interval_seconds` option that was set to 30 seconds